### PR TITLE
fix incorrect directory path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 ```bash
 # 克隆仓库
 git clone https://github.com/datawhalechina/diy-llm.git
-cd CS336-Chinese-co-construction
+cd diy-llm
 # 安装基础依赖（根据具体作业需求安装）
 ```
 


### PR DESCRIPTION
The cloned directory name is 'diy-llm' ,
but the README.md suggested 'CS336-Chinese-co-construction'.