### PR TITLE
feat(train): add MPS support and per-interval step timing

### DIFF
--- a/coursework/assignment1-basics/train.py
+++ b/coursework/assignment1-basics/train.py
@@ -181,6 +181,9 @@ def get_memory_usage(device):
         # 获取当前设备已分配的显存(MB)
         mem = torch.cuda.memory_allocated() / 1024 ** 2
         return f"{mem:.2f} MB (GPU)"
+    elif device == "mps":
+        mem = torch.mps.current_allocated_memory() / 1024 ** 2
+        return f"{mem:.2f} MB (MPS)"
     else:
         # 获取当前进程占用的系统内存 (MB)
         process = psutil.Process(os.getpid())
@@ -202,7 +205,12 @@ def main():
     parser.add_argument("--data_path", type=str, default="data.bin")
     args = parser.parse_args()
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif torch.backends.mps.is_available():
+        device = "mps"
+    else:
+        device = "cpu"
     print(f"Using Device: {device}")
     os.makedirs(args.checkpoint_dir, exist_ok=True)
 
@@ -294,6 +302,7 @@ def main():
         print(f"\n--- Epoch {epoch} ---")
         print(f"初始内存占用: {get_memory_usage(device)}")
 
+        step_interval_start = time.time()
         for batch_idx, (x, y) in enumerate(train_loader):
             x, y = x.to(device), y.to(device)
 
@@ -321,10 +330,13 @@ def main():
             step_t += 1
 
             if batch_idx % 100 == 0:  # 减少打印频率
+                step_interval_time = time.time() - step_interval_start
                 mem_status = get_memory_usage(device)
                 print(f"Step {batch_idx} | 实时内存: {mem_status}")
                 print(f"Epoch {epoch} | Step {step_t}/{total_steps} | "
-                      f"LR: {lr:.6f} | Train Loss: {loss_val:.4f} | Train PPL: {ppl_val:.4f}")
+                      f"LR: {lr:.6f} | Train Loss: {loss_val:.4f} | Train PPL: {ppl_val:.4f} | "
+                      f"Step Time: {step_interval_time:.2f}s")
+                step_interval_start = time.time()
 
         # Epoch结束统计
         if len(current_epoch_losses) > 0:


### PR DESCRIPTION
- Device selection now follows cuda > mps > cpu priority chain
- get_memory_usage adds mps branch via torch.mps.current_allocated_memory()
- Log 100-step elapsed time (Step Time: Xs) to each training progress line

在Apple M4 Pro上，加速6x，有利于加速训练:

**Using Device: cpu
模型参数量: 30.55M**

  --- Epoch 1 ---
  初始内存占用: 445.27 MB (CPU)
  Step 0 | 实时内存: 2790.08 MB (CPU)
  Epoch 1 | Step 1/53830 | LR: 0.000000 | Train Loss: 10.8260 | Train PPL: 50313.7457 | Step Time: 0.87s
  Step 100 | 实时内存: 3770.55 MB (CPU)
  Epoch 1 | Step 101/53830 | LR: 0.000006 | Train Loss: 10.7591 | Train PPL: 47058.5403 | Step Time: 69.49s
  Step 200 | 实时内存: 3842.62 MB (CPU)
  Epoch 1 | Step 201/53830 | LR: 0.000011 | Train Loss: 10.4299 | Train PPL: 33857.7451 | Step Time: 69.59s
  Step 300 | 实时内存: 3842.36 MB (CPU)
  Epoch 1 | Step 301/53830 | LR: 0.000017 | Train Loss: 9.8322 | Train PPL: 18624.1846 | Step Time: 70.34s
  Step 400 | 实时内存: 3853.69 MB (CPU)
  Epoch 1 | Step 401/53830 | LR: 0.000022 | Train Loss: 9.0184 | Train PPL: 8253.6726 | Step Time: 70.16s(fanchi) 
  
  **Using Device: mps
  模型参数量: 30.55M**

  --- Epoch 1 ---
  初始内存占用: 116.55 MB (MPS)
  Step 0 | 实时内存: 897.81 MB (MPS)
  Epoch 1 | Step 1/53830 | LR: 0.000000 | Train Loss: 10.8299 | Train PPL: 50509.5602 | Step Time: 2.60s
  Step 100 | 实时内存: 897.81 MB (MPS)
  Epoch 1 | Step 101/53830 | LR: 0.000006 | Train Loss: 10.7518 | Train PPL: 46714.3750 | Step Time: 11.17s
  Step 200 | 实时内存: 897.81 MB (MPS)
  Epoch 1 | Step 201/53830 | LR: 0.000011 | Train Loss: 10.4322 | Train PPL: 33936.3313 | Step Time: 11.25s
  Step 300 | 实时内存: 897.81 MB (MPS)
  Epoch 1 | Step 301/53830 | LR: 0.000017 | Train Loss: 9.8184 | Train PPL: 18368.8371 | Step Time: 11.38s
  Step 400 | 实时内存: 897.81 MB (MPS)
  Epoch 1 | Step 401/53830 | LR: 0.000022 | Train Loss: 8.9985 | Train PPL: 8091.1920 | Step Time: 11.48s