### PR TITLE
SFT 无用代码清理 + zero-shot 评测 temperature=0.0 对齐文档

### DIFF
--- a/coursework/assignment5-alignment/cs336_alignment/evaluate_math.py
+++ b/coursework/assignment5-alignment/cs336_alignment/evaluate_math.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
 
     # Set sampling parameters
     sampling_params = SamplingParams(
-        temperature=1.0,
+        temperature=0.0,
         top_p=1.0,
         max_tokens=1024,
         stop=["</answer>"],

--- a/coursework/assignment5-alignment/cs336_alignment/sft_helper.py
+++ b/coursework/assignment5-alignment/cs336_alignment/sft_helper.py
@@ -192,10 +192,3 @@ def sft_microbatch_train_step(
         "microbatch_loss": microbatch_loss.detach(),
     }
     return loss, metadata
-
-
-    return log_dict
-
-
-
-


### PR DESCRIPTION
# Summary
本次 PR 对 assignment5-alignment 做两处小修正：去掉 SFT 训练步函数末尾的无用代码，并将 zero-shot 数学评测的采样温度改为与作业文档及后续 SFT/RL 评估一致的 deterministic 设置（temperature=0.0）。

# Changes
## sft_helper.py — 移除不可达代码
在 sft_microbatch_train_step 中，正常返回 loss, metadata 之后曾残留 return log_dict 及多余空行；该分支在运行时永远不会执行。
删除这段代码。
## evaluate_math.py — 评测与 README §1.7 对齐
将 vLLM SamplingParams 中的 temperature 从 1.0 改为 0.0。
动机：README.ipynb §1.7 结果分析中的指标是在确定性解码下得到的；同时与作业中 SFT、RL 等环节使用的 eval_temperature=0.0 式评估设定一致，便于复现文档中的格式率、答案准确率与组合计数。